### PR TITLE
Allow Lens to update kube-config

### DIFF
--- a/dev.k8slens.OpenLens.yml
+++ b/dev.k8slens.OpenLens.yml
@@ -17,9 +17,9 @@ finish-args:
   - --talk-name=org.freedesktop.Notifications
   - --system-talk-name=org.freedesktop.login1
   # We use .kube/config to know what clusters/contexts are set up
-  - --filesystem=~/.kube/config:ro
+  - --filesystem=~/.kube/config
   # It's common to run minikube for experimenting, so it should be fine to read this dir
-  - --filesystem=~/.minikube:ro
+  - --filesystem=~/.minikube
   - --persist=.k8slens
 modules:
   - shared-modules/libsecret/libsecret.json


### PR DESCRIPTION
There is functionality which requires write permission no these files. Like the ability to remove/rename some cluster
![image](https://github.com/flathub/dev.k8slens.OpenLens/assets/11902307/39f9bd70-45eb-41ed-85ad-76d90f4f88e0)
