### PR TITLE
refactor: change app name to Lens Desktop Core

### DIFF
--- a/dev.k8slens.OpenLens.desktop
+++ b/dev.k8slens.OpenLens.desktop
@@ -1,5 +1,5 @@
 [Desktop Entry]
-Name=Open Lens
+Name=Lens Desktop Core
 Exec=open-lens %u
 Terminal=false
 Type=Application

--- a/dev.k8slens.OpenLens.metainfo.xml
+++ b/dev.k8slens.OpenLens.metainfo.xml
@@ -3,11 +3,11 @@
     <id>dev.k8slens.OpenLens</id>
     <metadata_license>CC0-1.0</metadata_license>
     <project_license>MIT</project_license>
-    <name>Open Lens</name>
+    <name>Lens Desktop Core</name>
     <summary>The Kubernetes IDE</summary>
     <description>
         <p>
-            Open Lens is the open-source core version of the Lens Desktop.
+            Lens Desktop Core is the open-source core version of the Lens Desktop.
 
             Lens is the most powerful IDE for people who need to deal with Kubernetes clusters on a
             daily basis. Ensure your clusters are properly setup and configured. Enjoy increased


### PR DESCRIPTION
To match the name in the official repository: https://github.com/lensapp/lens