### PR TITLE
Expose cloud provider configs

### DIFF
--- a/dev.k8slens.OpenLens.yml
+++ b/dev.k8slens.OpenLens.yml
@@ -21,6 +21,9 @@ finish-args:
   - --filesystem=~/.kube/config
   # It's common to run minikube for experimenting
   - --filesystem=~/.minikube
+  # cloud providers config/creds
+  - --filesystem=~/.aws
+  - --filesystem=~/.config/gcloud
   - --persist=.k8slens
 modules:
   - shared-modules/libsecret/libsecret.json


### PR DESCRIPTION
I realized that when I did the testing I had these two dirs added in flatseal. I've tried the last build from flathub and it was able to call aws/gcp binaries, but creds were missing. 