### PR TITLE
Mark OpenLens as EOL

### DIFF
--- a/flathub.json
+++ b/flathub.json
@@ -1,3 +1,4 @@
 {
-  "disable-external-data-checker": true
+  "disable-external-data-checker": true,
+  "end-of-life": "The open source version of Lens Desktop has been retired and is no longer maintained."
 }


### PR DESCRIPTION
> The open source version of Lens Desktop has been retired and is no longer maintained.

Source: https://github.com/lensapp/lens?tab=readme-ov-file#history-of-this-repository

> **End-of-life runtime transition**: 
> To focus our resources on maintaining high-quality, up-to-date runtimes, we'll be completing the removal of several end-of-life runtimes in January 2026. Apps using runtimes older than freedesktop-sdk 22.08, GNOME 45, KDE 5.15-22.08 or KDE 6.6 will be marked as EOL shortly. 

Source: https://docs.flathub.org/blog/enhanced-license-compliance-tools